### PR TITLE
Add Events to Transaction graphql query. Fix transaction details visualization

### DIFF
--- a/public/locales/en/message_contents.json
+++ b/public/locales/en/message_contents.json
@@ -59,7 +59,7 @@
   "MsgRevokeAllowance": "<0>{{granter}}</0> revoked allowance for <1>{{grantee}}</1>",
   "MsgCreateVestingAccount": "Vesting account created for <0>{{toAddress}}</0>",
   "MsgCreatePeriodicVestingAccount": "Periodic vesting account created for <0>{{toAddress}}</0>",
-  "txNFTMintContent": "Mint NFT From 0x0000... To <0>{{owner}}</0>",
+  "txNFTMintContent": "Mint NFT [ ID #<1>{{nftId}}</1> ] From 0x0000... To <0>{{owner}}</0>",
   "txNFTTransferContent": "Transfer NFT [ ID #<2>{{nftId}}</2> ] From <0>{{owner}}</0> To <1>{{to}}</1>",
   "txNFTBurnContent": "Burn NFT [ ID #<1>{{nftId}}</1> ] From <0>{{owner}}</0> To 0x000...",
   "txAddContractLogContent": "",

--- a/src/components/msg/utils.tsx
+++ b/src/components/msg/utils.tsx
@@ -632,15 +632,15 @@ export const getMessageByType = (message: any, viewRaw: boolean, t:any) => {
 };
 
 export const convertMsgsToModels = (transaction: any) => {
-  const messages = R.pathOr([], ['messages'], transaction).map((msg, i) => {
+  const messages = R.pathOr([], ['messages'], transaction).map((msg) => {
     const model = getMessageModelByType(msg?.['@type']);
     if (model === MODELS.MsgWithdrawDelegatorReward
       || model === MODELS.MsgWithdrawValidatorCommission
       || model === MODELS.MsgNFTMint
       || model === MODELS.MsgCosmwasmInstantiateContract
       || model === MODELS.MsgCosmwasmStoreCode) {
-      const log = R.pathOr(null, ['logs', i], transaction);
-      return model.fromJson(msg, log);
+      const events = R.pathOr(null, ['events'], transaction);
+      return model.fromJson(msg, events);
     }
     return model.fromJson(msg);
   });

--- a/src/components/single_transaction_mobile/index.tsx
+++ b/src/components/single_transaction_mobile/index.tsx
@@ -24,51 +24,51 @@ const SingleTransactionMobile:React.FC<{
     <div className={classnames(className, classes.root)}>
       <div className={classes.flex}>
         <div className={classes.item}>
-          <Typography variant="h4" className="label">
+          <Typography variant="h4" className="label" component={'span'}>
             {t('block')}
           </Typography>
           {block}
         </div>
         <div className={classes.item}>
-          <Typography variant="h4" className="label">
+          <Typography variant="h4" className="label" component={'span'}>
             {t('type')}
           </Typography>
-          <Typography variant="body1" className="value">
+          <Typography variant="body1" className="value" component={'span'}>
             {type}
           </Typography>
         </div>
       </div>
       <div className={classes.item}>
-        <Typography variant="h4" className="label">
+        <Typography variant="h4" className="label" component={'span'}>
           {t('hash')}
         </Typography>
-        <Typography variant="body1" className="value">
+        <Typography variant="body1" className="value" component={'span'}>
           {hash}
         </Typography>
       </div>
       <div className={classes.flex}>
         {!!messages && (
         <div className={classes.item}>
-          <Typography variant="h4" className="label">
+          <Typography variant="h4" className="label" component={'span'}>
             {t('messages')}
           </Typography>
-          <Typography variant="body1" className="value">
+          <Typography variant="body1" className="value" component={'span'}>
             {messages}
           </Typography>
         </div>
         )}
         <div className={classes.item}>
-          <Typography variant="h4" className="label">
+          <Typography variant="h4" className="label" component={'span'}>
             {t('result')}
           </Typography>
           {result}
         </div>
       </div>
       <div className={classes.item}>
-        <Typography variant="h4" className="label">
+        <Typography variant="h4" className="label" component={'span'}>
           {t('time')}
         </Typography>
-        <Typography variant="body1" className="value">
+        <Typography variant="body1" className="value" component={'span'}>
           {time}
         </Typography>
       </div>

--- a/src/graphql/transaction_details.graphql
+++ b/src/graphql/transaction_details.graphql
@@ -13,5 +13,6 @@ query TransactionDetails($hash: String) {
     messages: messages
     logs
     rawLog: raw_log
+    events
   }
 }

--- a/src/graphql/transactions.graphql
+++ b/src/graphql/transactions.graphql
@@ -8,6 +8,7 @@ subscription TransactionsListener($limit: Int = 7, $offset: Int = 0) {
     }
     messages
     logs
+    events
   }
 }
 
@@ -21,5 +22,6 @@ query Transactions($limit: Int = 7, $offset: Int = 0) {
     }
     messages
     logs
+    events
   }
 }

--- a/src/graphql/types.tsx
+++ b/src/graphql/types.tsx
@@ -15188,6 +15188,7 @@ export type Transaction = {
   __typename?: 'transaction';
   /** An object relationship */
   block: Block;
+  events: Scalars['jsonb'];
   fee: Scalars['jsonb'];
   gas_used?: Maybe<Scalars['bigint']>;
   gas_wanted?: Maybe<Scalars['bigint']>;
@@ -15201,6 +15202,12 @@ export type Transaction = {
   signatures: Array<Scalars['String']>;
   signer_infos: Scalars['jsonb'];
   success: Scalars['Boolean'];
+};
+
+
+/** columns and relationships of "transaction" */
+export type TransactionEventsArgs = {
+  path?: Maybe<Scalars['String']>;
 };
 
 
@@ -15301,6 +15308,7 @@ export type Transaction_Aggregate_Order_By = {
 
 /** append existing jsonb value of filtered columns with new jsonb value */
 export type Transaction_Append_Input = {
+  events?: Maybe<Scalars['jsonb']>;
   fee?: Maybe<Scalars['jsonb']>;
   logs?: Maybe<Scalars['jsonb']>;
   signer_infos?: Maybe<Scalars['jsonb']>;
@@ -15336,6 +15344,7 @@ export type Transaction_Bool_Exp = {
   _not?: Maybe<Transaction_Bool_Exp>;
   _or?: Maybe<Array<Transaction_Bool_Exp>>;
   block?: Maybe<Block_Bool_Exp>;
+  events?: Maybe<Jsonb_Comparison_Exp>;
   fee?: Maybe<Jsonb_Comparison_Exp>;
   gas_used?: Maybe<Bigint_Comparison_Exp>;
   gas_wanted?: Maybe<Bigint_Comparison_Exp>;
@@ -15359,6 +15368,7 @@ export enum Transaction_Constraint {
 
 /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
 export type Transaction_Delete_At_Path_Input = {
+  events?: Maybe<Array<Scalars['String']>>;
   fee?: Maybe<Array<Scalars['String']>>;
   logs?: Maybe<Array<Scalars['String']>>;
   signer_infos?: Maybe<Array<Scalars['String']>>;
@@ -15366,6 +15376,7 @@ export type Transaction_Delete_At_Path_Input = {
 
 /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
 export type Transaction_Delete_Elem_Input = {
+  events?: Maybe<Scalars['Int']>;
   fee?: Maybe<Scalars['Int']>;
   logs?: Maybe<Scalars['Int']>;
   signer_infos?: Maybe<Scalars['Int']>;
@@ -15373,6 +15384,7 @@ export type Transaction_Delete_Elem_Input = {
 
 /** delete key/value pair or string element. key/value pairs are matched based on their key value */
 export type Transaction_Delete_Key_Input = {
+  events?: Maybe<Scalars['String']>;
   fee?: Maybe<Scalars['String']>;
   logs?: Maybe<Scalars['String']>;
   signer_infos?: Maybe<Scalars['String']>;
@@ -15389,6 +15401,7 @@ export type Transaction_Inc_Input = {
 /** input type for inserting data into table "transaction" */
 export type Transaction_Insert_Input = {
   block?: Maybe<Block_Obj_Rel_Insert_Input>;
+  events?: Maybe<Scalars['jsonb']>;
   fee?: Maybe<Scalars['jsonb']>;
   gas_used?: Maybe<Scalars['bigint']>;
   gas_wanted?: Maybe<Scalars['bigint']>;
@@ -15480,6 +15493,7 @@ export type Transaction_On_Conflict = {
 /** Ordering options when selecting data from "transaction". */
 export type Transaction_Order_By = {
   block?: Maybe<Block_Order_By>;
+  events?: Maybe<Order_By>;
   fee?: Maybe<Order_By>;
   gas_used?: Maybe<Order_By>;
   gas_wanted?: Maybe<Order_By>;
@@ -15497,6 +15511,7 @@ export type Transaction_Order_By = {
 
 /** prepend existing jsonb value of filtered columns with new jsonb value */
 export type Transaction_Prepend_Input = {
+  events?: Maybe<Scalars['jsonb']>;
   fee?: Maybe<Scalars['jsonb']>;
   logs?: Maybe<Scalars['jsonb']>;
   signer_infos?: Maybe<Scalars['jsonb']>;
@@ -15504,6 +15519,8 @@ export type Transaction_Prepend_Input = {
 
 /** select columns of table "transaction" */
 export enum Transaction_Select_Column {
+  /** column name */
+  Events = 'events',
   /** column name */
   Fee = 'fee',
   /** column name */
@@ -15546,6 +15563,7 @@ export enum Transaction_Select_Column_Transaction_Aggregate_Bool_Exp_Bool_Or_Arg
 
 /** input type for updating data in table "transaction" */
 export type Transaction_Set_Input = {
+  events?: Maybe<Scalars['jsonb']>;
   fee?: Maybe<Scalars['jsonb']>;
   gas_used?: Maybe<Scalars['bigint']>;
   gas_wanted?: Maybe<Scalars['bigint']>;
@@ -15622,6 +15640,7 @@ export type Transaction_Stream_Cursor_Input = {
 
 /** Initial value of the column from where the streaming should start */
 export type Transaction_Stream_Cursor_Value_Input = {
+  events?: Maybe<Scalars['jsonb']>;
   fee?: Maybe<Scalars['jsonb']>;
   gas_used?: Maybe<Scalars['bigint']>;
   gas_wanted?: Maybe<Scalars['bigint']>;
@@ -15656,6 +15675,8 @@ export type Transaction_Sum_Order_By = {
 
 /** update columns of table "transaction" */
 export enum Transaction_Update_Column {
+  /** column name */
+  Events = 'events',
   /** column name */
   Fee = 'fee',
   /** column name */
@@ -19526,7 +19547,7 @@ export type TransactionDetailsQueryVariables = Exact<{
 
 export type TransactionDetailsQuery = { transaction: Array<(
     { __typename?: 'transaction' }
-    & Pick<Transaction, 'logs'>
+    & Pick<Transaction, 'logs' | 'events'>
     & { hash: Transaction['hash'], height: Transaction['height'], fee: Transaction['fee'], gasUsed: Transaction['gas_used'], gasWanted: Transaction['gas_wanted'], success: Transaction['success'], memo: Transaction['memo'], messages: Transaction['messages'], rawLog: Transaction['raw_log'] }
     & { block: (
       { __typename?: 'block' }
@@ -19542,7 +19563,7 @@ export type TransactionsListenerSubscriptionVariables = Exact<{
 
 export type TransactionsListenerSubscription = { transactions: Array<(
     { __typename?: 'transaction' }
-    & Pick<Transaction, 'height' | 'hash' | 'success' | 'messages' | 'logs'>
+    & Pick<Transaction, 'height' | 'hash' | 'success' | 'messages' | 'logs' | 'events'>
     & { block: (
       { __typename?: 'block' }
       & Pick<Block, 'timestamp'>
@@ -19557,7 +19578,7 @@ export type TransactionsQueryVariables = Exact<{
 
 export type TransactionsQuery = { transactions: Array<(
     { __typename?: 'transaction' }
-    & Pick<Transaction, 'height' | 'hash' | 'success' | 'messages' | 'logs'>
+    & Pick<Transaction, 'height' | 'hash' | 'success' | 'messages' | 'logs' | 'events'>
     & { block: (
       { __typename?: 'block' }
       & Pick<Block, 'timestamp'>
@@ -20977,6 +20998,7 @@ export const TransactionDetailsDocument = gql`
     messages: messages
     logs
     rawLog: raw_log
+    events
   }
 }
     `;
@@ -21023,6 +21045,7 @@ export const TransactionsListenerDocument = gql`
     }
     messages
     logs
+    events
   }
 }
     `;
@@ -21065,6 +21088,7 @@ export const TransactionsDocument = gql`
     }
     messages
     logs
+    events
   }
 }
     `;

--- a/src/models/msg/cosmwasm/msg_cosmwasm_instantiate_contract.ts
+++ b/src/models/msg/cosmwasm/msg_cosmwasm_instantiate_contract.ts
@@ -23,21 +23,36 @@ class MsgCosmwasmInstantiateContract {
       this.codeId = payload.codeId;
     }
 
-    static fromJson(json: any, log: any) {
+    static getInstantiateCodeId(events: any) {
+      if (events === null) {
+        return 'Unknown';
+      }
+      const WasmEvent = events.find(event =>
+        event.type === 'instantiate' &&
+        event.attributes?.some(attr => attr.key === 'code_id')
+      );
+    
+      const codeIdAttr = WasmEvent?.attributes?.find(attr => attr.key === 'code_id');
+      const codeId = codeIdAttr?.value || 'Unknown'; 
+      return codeId
+    }
+
+    static fromJson(json: any, events: any) {
       let contractAddress = 'NULL';
-      if(log !== null){
-        contractAddress = log.events.filter((v:any) => {
+      if(events !== null){
+        contractAddress = events.filter((v:any) => {
           return v.type === "instantiate"
         })[0].attributes[0].value;
       }
-
+      const codeId = this.getInstantiateCodeId(events);
+      
       return new MsgCosmwasmInstantiateContract({
         json,
         type: json['@type'],
         ownerAddress: json.sender,
         adminAddress: json.admin,
         contractAddress,
-        codeId: json.code_id
+        codeId
       });
     }
 }

--- a/src/models/msg/cosmwasm/msg_cosmwasm_storecode.ts
+++ b/src/models/msg/cosmwasm/msg_cosmwasm_storecode.ts
@@ -1,30 +1,47 @@
+import * as R from 'ramda';
+import { chainConfig } from '@configs';
+import { formatToken } from '@utils/format_token';
 import { Categories } from '../types';
 
 class MsgCosmwasmStoreCode {
-    public category: Categories;
-    public type: string;
-    public json: any;
+  public category: Categories;
+  public type: string;
+  public json: any;
 
-    public ownerAddress: string;
-    public codeId: string;
+  public ownerAddress: string;
+  public codeId: string;
 
-    constructor(payload: any) {
-      this.category = 'nft';
-      this.type = payload.type;
-      this.json = payload.json;
+  constructor(payload: any) {
+    this.category = 'nft';
+    this.type = payload.type;
+    this.json = payload.json;
 
-      this.ownerAddress = payload.ownerAddress;
-      this.codeId = payload.codeId;
+    this.ownerAddress = payload.ownerAddress;
+    this.codeId = payload.codeId;
+  }
+  static getCodeId(events: any) {
+    if (events === null) {
+      return 'Unknown';
     }
+    const WasmEvent = events.find(event =>
+      event.type === 'store_code' &&
+      event.attributes?.some(attr => attr.key === 'code_id')
+    );
+  
+    const codeIdAttr = WasmEvent?.attributes?.find(attr => attr.key === 'code_id');
+    const codeId = codeIdAttr?.value || 'Unknown'; 
+    return codeId
+  }
 
-    static fromJson(json: any, log: any) {
-      return new MsgCosmwasmStoreCode({
-        json,
-        type: json['@type'],
-        ownerAddress: json.sender,
-        codeId: log ? log.events[1].attributes[1].value : 'UNKNWON',
-      });
-    }
+  static fromJson(json: any, events: any) {
+    const codeId = this.getCodeId(events);
+    return new MsgCosmwasmStoreCode({
+      json,
+      type: json['@type'],
+      ownerAddress: json.sender,
+      codeId,
+    });
+  }
 }
 
 export default MsgCosmwasmStoreCode;

--- a/src/models/msg/distribution/msg_withdraw_validator_commission.ts
+++ b/src/models/msg/distribution/msg_withdraw_validator_commission.ts
@@ -18,11 +18,11 @@ class MsgWithdrawValidatorCommission {
     this.json = payload.json;
   }
 
-  static getWithdrawalAmount(log: any) {
-    if(log === null) {
+  static getWithdrawalAmount(events: any) {
+    if(events === null) {
       return [formatToken(0)];
     }
-    const withdrawEvents = R.pathOr([], ['events'], log).filter((x) => x.type === 'withdraw_commission');
+    const withdrawEvents = events.filter((x) => x.type === 'withdraw_commission');
     const withdrawAmounts = R.pathOr([], [0, 'attributes'], withdrawEvents).filter((x) => x.key === 'amount');
 
     const amounts = R.pathOr('0', [0, 'value'], withdrawAmounts).split(',').map((x) => {
@@ -33,8 +33,8 @@ class MsgWithdrawValidatorCommission {
     return amounts;
   }
 
-  static fromJson(json: any, log?: any) {
-    const amounts = this.getWithdrawalAmount(log);
+  static fromJson(json: any, events?: any) {
+    const amounts = this.getWithdrawalAmount(events);
 
     return new MsgWithdrawValidatorCommission({
       json,

--- a/src/models/msg/distribution/msg_withdrawal_delegator_reward.ts
+++ b/src/models/msg/distribution/msg_withdrawal_delegator_reward.ts
@@ -20,11 +20,11 @@ class MsgWithdrawDelegatorReward {
     this.json = payload.json;
   }
 
-  static getWithdrawalAmount(log: any) {
-    if(log === null) {
+  static getWithdrawalAmount(events: any) {
+    if(events === null) {
       return [formatToken(0)];
     }
-    const withdrawEvents = R.pathOr([], ['events'], log).filter((x) => x.type === 'withdraw_rewards');
+    const withdrawEvents = events.filter((x) => x.type === 'withdraw_rewards');
     const withdrawAmounts = R.pathOr([], [0, 'attributes'], withdrawEvents).filter((x) => x.key === 'amount');
 
     const amounts = R.pathOr('0', [0, 'value'], withdrawAmounts).split(',').map((x) => {
@@ -35,8 +35,8 @@ class MsgWithdrawDelegatorReward {
     return amounts;
   }
 
-  static fromJson(json: any, log?: any) {
-    const amounts = this.getWithdrawalAmount(log);
+  static fromJson(json: any, events?: any) {
+    const amounts = this.getWithdrawalAmount(events);
 
     return new MsgWithdrawDelegatorReward({
       json,

--- a/src/models/msg/nft/msg_nft_mint.ts
+++ b/src/models/msg/nft/msg_nft_mint.ts
@@ -19,15 +19,22 @@ class MsgNFTMint {
       this.nftId = payload.nftId;
     }
 
-    static fromJson(json: any, log: any) {
+    static fromJson(json: any, events: any[]) {
+      const nftEvent = events.find(event =>
+        event.type === 'message' &&
+        event.attributes?.some(attr => attr.key === 'nftID')
+      );
+    
+      const nftIdAttr = nftEvent?.attributes?.find(attr => attr.key === 'nftID');
+      const nftId = nftIdAttr?.value || 'Unknown'; 
+    
       return new MsgNFTMint({
         json,
         type: json['@type'],
         owner: json.owner,
         tokenURI: json.tokenURI,
-        nftId: 0
+        nftId
       });
-    }
-}
-
+    };
+  };
 export default MsgNFTMint;

--- a/src/screens/transactions/hooks.ts
+++ b/src/screens/transactions/hooks.ts
@@ -17,6 +17,7 @@ export const useTransactions = () => {
     isNextPageLoading: false,
     items: [],
   });
+  console.log("state1:", state);
 
   const handleSetState = (stateChange: any) => {
     setState((prevState) => R.mergeDeepLeft(stateChange, prevState));


### PR DESCRIPTION
This PR:

- Fix NftId visualization when a NftMint transaction is done
- Fix CodeId visualization when a Wasm Store Code transaction is done
- Fix InstantiateCodeId visualization when a Wasm Instantiate contract transaction is done
- Fix InstantiateCodeId visualization when a Distribution withdraw_reward transaction is done
- Update Hasura types and graphql query.
- Fix warning of Typography